### PR TITLE
Fixed wrong references to renamed interface

### DIFF
--- a/src/ClientMiddlewareInterface.php
+++ b/src/ClientMiddlewareInterface.php
@@ -14,9 +14,9 @@ interface ClientMiddlewareInterface extends MiddlewareInterface
      * to the next frame to get a response.
      *
      * @param RequestInterface $request
-     * @param FrameInterface $next
+     * @param DelegateInterface $next
      *
      * @return ResponseInterface
      */
-    public function process(RequestInterface $request, FrameInterface $next);
+    public function process(RequestInterface $request, DelegateInterface $next);
 }

--- a/src/ServerMiddlewareInterface.php
+++ b/src/ServerMiddlewareInterface.php
@@ -14,9 +14,9 @@ interface ServerMiddlewareInterface extends MiddlewareInterface
      * to the next frame to get a response.
      *
      * @param ServerRequestInterface $request
-     * @param FrameInterface $frame
+     * @param DelegateInterface $frame
      *
      * @return ResponseInterface
      */
-    public function process(ServerRequestInterface $request, FrameInterface $frame);
+    public function process(ServerRequestInterface $request, DelegateInterface $frame);
 }


### PR DESCRIPTION
Rename the type hint of `FrameInterface` to `DelegateInterface`
