### PR TITLE
[PoC][WiP] callables

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+tests/                 export-ignore
+.gitattributes         export-ignore
+.gitignore             export-ignore
+.pullapprove.yml       export-ignore
+.travis.yml            export-ignore
+phpcs.xml              export-ignore
+phpunit.xml.dist       export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+build/
+vendor/
+composer.lock
+composer.phar
+phpunit.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+language: php
+sudo: false
+
+php:
+  - '5.4'
+  - '5.5'
+  - '5.6'
+  - '7.0'
+  - '7.1'
+  - nightly
+  - hhvm
+
+install:
+  - composer selfupdate
+  - composer install
+  - if [ "$TRAVIS_PHP_VERSION" \> "5.5" ]; then composer require --dev phpunit/phpunit; fi
+
+
+script:
+  - if [ "$TRAVIS_PHP_VERSION" \< "5.6" ]; then composer smoke-test; else composer test; fi

--- a/composer.json
+++ b/composer.json
@@ -20,16 +20,49 @@
     ],
     "require": {
         "php": ">=5.3.0",
-        "psr/http-message": "^1.0"
+        "psr/http-message": "^1.0",
+        "raphhh/trex-reflection": "^0.2.3"
+    },
+    "require-dev": {
+        "zendframework/zend-coding-standard": "^1.0"
     },
     "autoload": {
+        "files": [
+            "src/functions.php"
+        ],
         "psr-4": {
             "Interop\\Http\\Middleware\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "files": [
+            "tests/Fixtures/Middlewares/Invalid/functions.php",
+            "tests/Fixtures/Middlewares/Valid/functions.php",
+            "tests/Fixtures/Delegates/Invalid/functions.php",
+            "tests/Fixtures/Delegates/Valid/functions.php"
+        ],
+        "psr-4": {
+            "Interop\\Http\\Middleware\\": "tests/"
         }
     },
     "extra": {
         "branch-alias": {
             "dev-master": "1.0.x-dev"
         }
+    },
+    "scripts": {
+        "check": [
+            "@cs-check",
+            "@test"
+        ],
+        "test": [
+            "@smoke-test",
+            "@unit-test"
+        ],
+        "cs-check": "phpcs --colors",
+        "cs-fix": "phpcbf --colors",
+        "smoke-test": "php tests/smoke-test.php",
+        "unit-test": "phpunit --colors=always",
+        "test-coverage": "phpunit --coverage-clover clover.xml"
     }
 }

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<ruleset name="Zend Framework Coding Standard">
+    <rule ref="./vendor/zendframework/zend-coding-standard/ruleset.xml"/>
+    <file>src</file>
+    <file>tests</file>
+</ruleset>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,6 +1,6 @@
 <phpunit bootstrap="./vendor/autoload.php" colors="true">
     <testsuites>
-        <testsuite name="Zend\\Stratigility Tests">
+        <testsuite>
             <directory>./tests</directory>
         </testsuite>
     </testsuites>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,17 @@
+<phpunit bootstrap="./vendor/autoload.php" colors="true">
+    <testsuites>
+        <testsuite name="Zend\\Stratigility Tests">
+            <directory>./tests</directory>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist addUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">./src</directory>
+        </whitelist>
+    </filter>
+    <logging>
+        <log type="coverage-text" target="php://stdout"/>
+        <log type="coverage-html" target="build/coverage" charset="UTF-8" yui="true" highlight="true"/>
+        <log type="coverage-clover" target="build/logs/clover.xml"/>
+    </logging>
+</phpunit>

--- a/src/DelegateInterface.php
+++ b/src/DelegateInterface.php
@@ -8,7 +8,7 @@ use Psr\Http\Message\ResponseInterface;
 interface DelegateInterface
 {
     /**
-     * Process a request and return the response.
+     * Dispatch the next available middleware and return the response.
      *
      * @param RequestInterface $request
      *

--- a/src/DelegateInterface.php
+++ b/src/DelegateInterface.php
@@ -8,11 +8,11 @@ use Psr\Http\Message\ResponseInterface;
 interface DelegateInterface
 {
     /**
-     * Dispatch the next available middleware and return the response.
+     * Process a request and return the response.
      *
      * @param RequestInterface $request
      *
      * @return ResponseInterface
      */
-    public function process(RequestInterface $request);
+    public function __invoke(RequestInterface $request);
 }

--- a/src/ServerMiddlewareInterface.php
+++ b/src/ServerMiddlewareInterface.php
@@ -9,12 +9,12 @@ interface ServerMiddlewareInterface
 {
     /**
      * Process an incoming server request and return a response, optionally delegating
-     * to the next middleware component to create the response.
+     * the response utilizing $delegate.
      *
-     * @param ServerRequestInterface $request
-     * @param DelegateInterface $delegate
+     * @param ServerRequestInterface     $request
+     * @param DelegateInterface|callable $delegate
      *
      * @return ResponseInterface
      */
-    public function process(ServerRequestInterface $request, DelegateInterface $delegate);
+    public function __invoke(ServerRequestInterface $request, callable $delegate);
 }

--- a/src/ServerMiddlewareInterface.php
+++ b/src/ServerMiddlewareInterface.php
@@ -9,7 +9,7 @@ interface ServerMiddlewareInterface
 {
     /**
      * Process an incoming server request and return a response, optionally delegating
-     * the response utilizing $delegate.
+     * the request utilizing $delegate.
      *
      * @param ServerRequestInterface     $request
      * @param DelegateInterface|callable $delegate

--- a/src/functions.php
+++ b/src/functions.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Interop\Http\Middleware;
+
+use ReflectionException;
+use ReflectionFunctionAbstract;
+use TRex\Reflection\CallableReflection;
+
+if (! function_exists('Interop\Http\Middleware\is_delegate')) {
+    /**
+     * Verify that the contents of a variable can be called as a delegate.
+     *
+     * @param mixed $var The value to check
+     *
+     * @return bool Returns TRUE if var is a delegate, FALSE otherwise.
+     * @throws ReflectionException if the function does not exist.
+     */
+    function is_delegate($var)
+    {
+        /* short circuit for interface implementers */
+        if ($var instanceof DelegateInterface) {
+            return true;
+        }
+
+        if (! is_callable($var)) {
+            return false;
+        }
+
+        /* @var $refFunc ReflectionFunctionAbstract */
+        $refFunc = (new CallableReflection($var))->getReflector();
+
+        if (1 !== $refFunc->getNumberOfRequiredParameters()) {
+            return false;
+        }
+
+        $request = $refFunc->getParameters()[0];
+
+        if (null === $requestClass = $request->getClass()) {
+            return false;
+        }
+
+        return $requestClass->getName() === 'Psr\Http\Message\RequestInterface';
+    }
+}
+
+if (! function_exists('Interop\Http\Middleware\is_server_middleware')) {
+    /**
+     * Verify that the contents of a variable can be called as a middleware.
+     *
+     * @param mixed $var The value to check
+     *
+     * @return bool Returns TRUE if var is a middleware, FALSE otherwise.
+     * @throws ReflectionException if the function does not exist.
+     */
+    function is_server_middleware($var)
+    {
+        /* short circuit for interface implementers */
+        if ($var instanceof ServerMiddlewareInterface) {
+            return true;
+        }
+
+        if (! is_callable($var)) {
+            return false;
+        }
+
+        /* @var $refFunc ReflectionFunctionAbstract */
+        $refFunc = (new CallableReflection($var))->getReflector();
+
+        if (2 !== $refFunc->getNumberOfRequiredParameters()) {
+            return false;
+        }
+
+        list($request, $delegate) = $refFunc->getParameters();
+
+        /* first parameter */
+        if (null === $requestClass = $request->getClass()) {
+            return false;
+        }
+
+        if ($requestClass->getName() !== 'Psr\Http\Message\ServerRequestInterface') {
+            return false;
+        }
+
+        /* second parameter */
+        return $delegate->isCallable();
+    }
+}

--- a/src/functions.php
+++ b/src/functions.php
@@ -6,82 +6,78 @@ use ReflectionException;
 use ReflectionFunctionAbstract;
 use TRex\Reflection\CallableReflection;
 
-if (! function_exists('Interop\Http\Middleware\is_delegate')) {
-    /**
-     * Verify that the contents of a variable can be called as a delegate.
-     *
-     * @param mixed $var The value to check
-     *
-     * @return bool Returns TRUE if var is a delegate, FALSE otherwise.
-     * @throws ReflectionException if the function does not exist.
-     */
-    function is_delegate($var)
-    {
-        /* short circuit for interface implementers */
-        if ($var instanceof DelegateInterface) {
-            return true;
-        }
-
-        if (! is_callable($var)) {
-            return false;
-        }
-
-        /* @var $refFunc ReflectionFunctionAbstract */
-        $refFunc = (new CallableReflection($var))->getReflector();
-
-        if (1 !== $refFunc->getNumberOfRequiredParameters()) {
-            return false;
-        }
-
-        $request = $refFunc->getParameters()[0];
-
-        if (null === $requestClass = $request->getClass()) {
-            return false;
-        }
-
-        return $requestClass->getName() === 'Psr\Http\Message\RequestInterface';
+/**
+ * Verify that the contents of a variable can be called as a delegate.
+ *
+ * @param mixed $var The value to check
+ *
+ * @return bool Returns TRUE if var is a delegate, FALSE otherwise.
+ * @throws ReflectionException if the function does not exist.
+ */
+function is_delegate($var)
+{
+    /* short circuit for interface implementers */
+    if ($var instanceof DelegateInterface) {
+        return true;
     }
+
+    if (! is_callable($var)) {
+        return false;
+    }
+
+    /* @var $refFunc ReflectionFunctionAbstract */
+    $refFunc = (new CallableReflection($var))->getReflector();
+
+    if (1 !== $refFunc->getNumberOfRequiredParameters()) {
+        return false;
+    }
+
+    $request = $refFunc->getParameters()[0];
+
+    if (null === $requestClass = $request->getClass()) {
+        return false;
+    }
+
+    return $requestClass->getName() === 'Psr\Http\Message\RequestInterface';
 }
 
-if (! function_exists('Interop\Http\Middleware\is_server_middleware')) {
-    /**
-     * Verify that the contents of a variable can be called as a middleware.
-     *
-     * @param mixed $var The value to check
-     *
-     * @return bool Returns TRUE if var is a middleware, FALSE otherwise.
-     * @throws ReflectionException if the function does not exist.
-     */
-    function is_server_middleware($var)
-    {
-        /* short circuit for interface implementers */
-        if ($var instanceof ServerMiddlewareInterface) {
-            return true;
-        }
-
-        if (! is_callable($var)) {
-            return false;
-        }
-
-        /* @var $refFunc ReflectionFunctionAbstract */
-        $refFunc = (new CallableReflection($var))->getReflector();
-
-        if (2 !== $refFunc->getNumberOfRequiredParameters()) {
-            return false;
-        }
-
-        list($request, $delegate) = $refFunc->getParameters();
-
-        /* first parameter */
-        if (null === $requestClass = $request->getClass()) {
-            return false;
-        }
-
-        if ($requestClass->getName() !== 'Psr\Http\Message\ServerRequestInterface') {
-            return false;
-        }
-
-        /* second parameter */
-        return $delegate->isCallable();
+/**
+ * Verify that the contents of a variable can be called as a middleware.
+ *
+ * @param mixed $var The value to check
+ *
+ * @return bool Returns TRUE if var is a middleware, FALSE otherwise.
+ * @throws ReflectionException if the function does not exist.
+ */
+function is_server_middleware($var)
+{
+    /* short circuit for interface implementers */
+    if ($var instanceof ServerMiddlewareInterface) {
+        return true;
     }
+
+    if (! is_callable($var)) {
+        return false;
+    }
+
+    /* @var $refFunc ReflectionFunctionAbstract */
+    $refFunc = (new CallableReflection($var))->getReflector();
+
+    if (2 !== $refFunc->getNumberOfRequiredParameters()) {
+        return false;
+    }
+
+    list($request, $delegate) = $refFunc->getParameters();
+
+    /* first parameter */
+    if (null === $requestClass = $request->getClass()) {
+        return false;
+    }
+
+    if ($requestClass->getName() !== 'Psr\Http\Message\ServerRequestInterface') {
+        return false;
+    }
+
+    /* second parameter */
+    return $delegate->isCallable();
 }

--- a/tests/Fixtures/Delegates/Invalid/MagicCall.php
+++ b/tests/Fixtures/Delegates/Invalid/MagicCall.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Interop\Http\Middleware\Fixtures\Delegates\Invalid;
+
+class MagicCall
+{
+    public function __call($name, $arguments)
+    {
+        if ($name === '__invoke') {
+            return null;
+        }
+
+        if ($name === 'delegate') {
+            return null;
+        }
+    }
+
+    public static function __callStatic($name, $arguments)
+    {
+        if ($name === '__invoke') {
+            return null;
+        }
+
+        if ($name === 'delegate') {
+            return null;
+        }
+    }
+}

--- a/tests/Fixtures/Delegates/Invalid/PureInvokableWithMixedRequest.php
+++ b/tests/Fixtures/Delegates/Invalid/PureInvokableWithMixedRequest.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Interop\Http\Middleware\Fixtures\Delegates\Invalid;
+
+class PureInvokableWithMixedRequest
+{
+    /**
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     */
+    public function __invoke($request)
+    {
+        return null;
+    }
+}

--- a/tests/Fixtures/Delegates/Invalid/PureInvokableWithoutRequest.php
+++ b/tests/Fixtures/Delegates/Invalid/PureInvokableWithoutRequest.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Interop\Http\Middleware\Fixtures\Delegates\Invalid;
+
+class PureInvokableWithoutRequest
+{
+    public function __invoke()
+    {
+        return null;
+    }
+}

--- a/tests/Fixtures/Delegates/Invalid/StaticDelegateWithMixedRequest.php
+++ b/tests/Fixtures/Delegates/Invalid/StaticDelegateWithMixedRequest.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Interop\Http\Middleware\Fixtures\Delegates\Invalid;
+
+class StaticDelegateWithMixedRequest
+{
+    /**
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     */
+    public static function delegate($request)
+    {
+        return null;
+    }
+}

--- a/tests/Fixtures/Delegates/Invalid/StaticDelegateWithoutRequest.php
+++ b/tests/Fixtures/Delegates/Invalid/StaticDelegateWithoutRequest.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Interop\Http\Middleware\Fixtures\Delegates\Invalid;
+
+class StaticDelegateWithoutRequest
+{
+    public static function delegate()
+    {
+        return null;
+    }
+}

--- a/tests/Fixtures/Delegates/Invalid/functions.php
+++ b/tests/Fixtures/Delegates/Invalid/functions.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Interop\Http\Middleware\Fixtures\Delegates\Invalid;
+
+function fnWithoutRequest()
+{
+    return null;
+}
+
+function fnWithoutRequestFactory()
+{
+    return function () {
+        return null;
+    };
+}
+
+/**
+ * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+ */
+function fnWithMixedRequest($request)
+{
+    return null;
+}
+
+function fnWithMixedRequestFactory()
+{
+    /**
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     */
+    return function ($request) {
+        return null;
+    };
+}

--- a/tests/Fixtures/Delegates/Valid/Delegate.php
+++ b/tests/Fixtures/Delegates/Valid/Delegate.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Interop\Http\Middleware\Fixtures\Delegates\Valid;
+
+use Psr\Http\Message\RequestInterface;
+use Interop\Http\Middleware\DelegateInterface;
+
+class Delegate implements DelegateInterface
+{
+    public function __invoke(RequestInterface $request)
+    {
+        return null;
+    }
+}

--- a/tests/Fixtures/Delegates/Valid/PureInvokable.php
+++ b/tests/Fixtures/Delegates/Valid/PureInvokable.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Interop\Http\Middleware\Fixtures\Delegates\Valid;
+
+use Psr\Http\Message\RequestInterface;
+
+class PureInvokable
+{
+    /**
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     */
+    public function __invoke(RequestInterface $request)
+    {
+        return null;
+    }
+}

--- a/tests/Fixtures/Delegates/Valid/StaticDelegate.php
+++ b/tests/Fixtures/Delegates/Valid/StaticDelegate.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Interop\Http\Middleware\Fixtures\Delegates\Valid;
+
+use Psr\Http\Message\RequestInterface;
+
+class StaticDelegate
+{
+    /**
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     */
+    public static function delegate(RequestInterface $request)
+    {
+        return null;
+    }
+}

--- a/tests/Fixtures/Delegates/Valid/functions.php
+++ b/tests/Fixtures/Delegates/Valid/functions.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Interop\Http\Middleware\Fixtures\Delegates\Valid;
+
+use Psr\Http\Message\RequestInterface;
+
+/**
+ * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+ */
+function fnDelegate(RequestInterface $request)
+{
+    return null;
+}
+
+function fnDelegateFactory()
+{
+    /**
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     */
+    return function (RequestInterface $request) {
+        return null;
+    };
+}

--- a/tests/Fixtures/Middlewares/Invalid/MagicCall.php
+++ b/tests/Fixtures/Middlewares/Invalid/MagicCall.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Interop\Http\Middleware\Fixtures\Middlewares\Invalid;
+
+class MagicCall
+{
+    public function __call($name, $arguments)
+    {
+        if ($name === '__invoke') {
+            $delegate = $arguments[1];
+
+            return $delegate($arguments[0]);
+        }
+
+        if ($name === 'delegate') {
+            $delegate = $arguments[1];
+
+            return $delegate($arguments[0]);
+        }
+    }
+
+    public static function __callStatic($name, $arguments)
+    {
+        if ($name === '__invoke') {
+            $delegate = $arguments[1];
+
+            return $delegate($arguments[0]);
+        }
+
+        if ($name === 'delegate') {
+            $delegate = $arguments[1];
+
+            return $delegate($arguments[0]);
+        }
+    }
+}

--- a/tests/Fixtures/Middlewares/Invalid/PureInvokableDoublePass.php
+++ b/tests/Fixtures/Middlewares/Invalid/PureInvokableDoublePass.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Interop\Http\Middleware\Fixtures\Middlewares\Invalid;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+class PureInvokableDoublePass
+{
+    /**
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     */
+    public function __invoke(ServerRequestInterface $request, ResponseInterface $response)
+    {
+        return $response;
+    }
+}

--- a/tests/Fixtures/Middlewares/Invalid/PureInvokableWithDelegate.php
+++ b/tests/Fixtures/Middlewares/Invalid/PureInvokableWithDelegate.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Interop\Http\Middleware\Fixtures\Middlewares\Invalid;
+
+use Psr\Http\Message\ServerRequestInterface;
+use Interop\Http\Middleware\DelegateInterface;
+
+class PureInvokableWithDelegate
+{
+    public function __invoke(ServerRequestInterface $request, DelegateInterface $delegate)
+    {
+        return $delegate($request);
+    }
+}

--- a/tests/Fixtures/Middlewares/Invalid/PureInvokableWithMixedRequest.php
+++ b/tests/Fixtures/Middlewares/Invalid/PureInvokableWithMixedRequest.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Interop\Http\Middleware\Fixtures\Middlewares\Invalid;
+
+class PureInvokableWithMixedRequest
+{
+    public function __invoke($request, callable $delegate)
+    {
+        return $delegate($request);
+    }
+}

--- a/tests/Fixtures/Middlewares/Invalid/PureInvokableWithoutDelegate.php
+++ b/tests/Fixtures/Middlewares/Invalid/PureInvokableWithoutDelegate.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Interop\Http\Middleware\Fixtures\Middlewares\Invalid;
+
+use Psr\Http\Message\ServerRequestInterface;
+
+class PureInvokableWithoutDelegate
+{
+    /**
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     */
+    public function __invoke(ServerRequestInterface $request)
+    {
+        return null;
+    }
+}

--- a/tests/Fixtures/Middlewares/Invalid/StaticMiddlewareDoublePass.php
+++ b/tests/Fixtures/Middlewares/Invalid/StaticMiddlewareDoublePass.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Interop\Http\Middleware\Fixtures\Middlewares\Invalid;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+class StaticMiddlewareDoublePass
+{
+    /**
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     */
+    public static function middleware(ServerRequestInterface $request, ResponseInterface $response)
+    {
+        return $response;
+    }
+}

--- a/tests/Fixtures/Middlewares/Invalid/StaticMiddlewareWithMixedRequest.php
+++ b/tests/Fixtures/Middlewares/Invalid/StaticMiddlewareWithMixedRequest.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Interop\Http\Middleware\Fixtures\Middlewares\Invalid;
+
+class StaticMiddlewareWithMixedRequest
+{
+    public static function middleware($request, callable $delegate)
+    {
+        return $delegate($request);
+    }
+}

--- a/tests/Fixtures/Middlewares/Invalid/StaticMiddlewareWithoutDelegate.php
+++ b/tests/Fixtures/Middlewares/Invalid/StaticMiddlewareWithoutDelegate.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Interop\Http\Middleware\Fixtures\Middlewares\Invalid;
+
+use Psr\Http\Message\ServerRequestInterface;
+
+class StaticMiddlewareWithoutDelegate
+{
+    /**
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     */
+    public static function middleware(ServerRequestInterface $request)
+    {
+        return null;
+    }
+}

--- a/tests/Fixtures/Middlewares/Invalid/functions.php
+++ b/tests/Fixtures/Middlewares/Invalid/functions.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Interop\Http\Middleware\Fixtures\Middlewares\Invalid;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Interop\Http\Middleware\DelegateInterface;
+
+/**
+ * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+ */
+function fnDoublePass(ServerRequestInterface $request, ResponseInterface $response)
+{
+    return $response;
+}
+
+function fnDoublePassFactory()
+{
+    /**
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     */
+    return function (ServerRequestInterface $request, ResponseInterface $response) {
+        return $response;
+    };
+}
+
+function fnWithDelegate(ServerRequestInterface $request, DelegateInterface $delegate)
+{
+    return $delegate($request);
+}
+
+function fnWithDelegateFactory()
+{
+    return function (ServerRequestInterface $request, DelegateInterface $delegate) {
+        return $delegate($request);
+    };
+}
+
+function fnWithMixedRequest($request, callable $delegate)
+{
+    return $delegate($request);
+}
+
+function fnWithMixedRequestFactory()
+{
+    return function ($request, callable $delegate) {
+        return $delegate($request);
+    };
+}
+
+/**
+ * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+ */
+function fnWithoutDelegate(ServerRequestInterface $request)
+{
+    return null;
+}
+
+function fnWithoutDelegateFactory()
+{
+    /**
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     */
+    return function (ServerRequestInterface $request) {
+        return null;
+    };
+}

--- a/tests/Fixtures/Middlewares/Valid/Middleware.php
+++ b/tests/Fixtures/Middlewares/Valid/Middleware.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Interop\Http\Middleware\Fixtures\Middlewares\Valid;
+
+use Psr\Http\Message\ServerRequestInterface;
+use Interop\Http\Middleware\ServerMiddlewareInterface;
+
+class Middleware implements ServerMiddlewareInterface
+{
+    public function __invoke(ServerRequestInterface $request, callable $delegate)
+    {
+        return $delegate($request);
+    }
+}

--- a/tests/Fixtures/Middlewares/Valid/PureInvokable.php
+++ b/tests/Fixtures/Middlewares/Valid/PureInvokable.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Interop\Http\Middleware\Fixtures\Middlewares\Valid;
+
+use Psr\Http\Message\ServerRequestInterface;
+
+class PureInvokable
+{
+    public function __invoke(ServerRequestInterface $request, callable $delegate)
+    {
+        return $delegate($request);
+    }
+}

--- a/tests/Fixtures/Middlewares/Valid/StaticMiddleware.php
+++ b/tests/Fixtures/Middlewares/Valid/StaticMiddleware.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Interop\Http\Middleware\Fixtures\Middlewares\Valid;
+
+use Psr\Http\Message\ServerRequestInterface;
+
+class StaticMiddleware
+{
+    public static function middleware(ServerRequestInterface $request, callable $delegate)
+    {
+        return $delegate($request);
+    }
+}

--- a/tests/Fixtures/Middlewares/Valid/functions.php
+++ b/tests/Fixtures/Middlewares/Valid/functions.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Interop\Http\Middleware\Fixtures\Middlewares\Valid;
+
+use Psr\Http\Message\ServerRequestInterface;
+
+function fnMiddleware(ServerRequestInterface $request, callable $delegate)
+{
+    return $delegate($request);
+}
+
+function fnMiddlewareFactory()
+{
+    return function (ServerRequestInterface $request, callable $delegate) {
+        return $delegate($request);
+    };
+}

--- a/tests/IsDelegateInvalidTest.php
+++ b/tests/IsDelegateInvalidTest.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace Interop\Http\Middleware;
+
+use ReflectionException;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Interop\Http\Middleware\Fixtures\Delegates\Invalid\MagicCall;
+use Interop\Http\Middleware\Fixtures\Delegates\Invalid\PureInvokableWithMixedRequest;
+use Interop\Http\Middleware\Fixtures\Delegates\Invalid\PureInvokableWithoutRequest;
+use Interop\Http\Middleware\Fixtures\Delegates\Invalid\StaticDelegateWithMixedRequest;
+use Interop\Http\Middleware\Fixtures\Delegates\Invalid\StaticDelegateWithoutRequest;
+
+use function Interop\Http\Middleware\Fixtures\Delegates\Invalid\fnWithoutRequestFactory;
+use function Interop\Http\Middleware\Fixtures\Delegates\Invalid\fnWithMixedRequestFactory;
+
+class IsDelegateInvalidTest extends \PHPUnit_Framework_TestCase
+{
+    public function testFnWithoutRequestShouldBeInvalid()
+    {
+        $this->assertSame(
+            false,
+            is_delegate('Interop\Http\Middleware\Fixtures\Delegates\Invalid\fnWithoutRequest')
+        );
+    }
+
+    public function testFnWithoutRequestFactoryShouldBeInvalid()
+    {
+        $sut = fnWithoutRequestFactory();
+        $this->assertSame(false, is_delegate($sut));
+    }
+
+    public function testFnWithMixedRequestShouldBeInvalid()
+    {
+        $this->assertSame(
+            false,
+            is_delegate('Interop\Http\Middleware\Fixtures\Delegates\Invalid\fnWithMixedRequest')
+        );
+    }
+
+    public function testFnWithMixedRequestFactoryShouldBeInvalid()
+    {
+        $sut = fnWithMixedRequestFactory();
+        $this->assertSame(false, is_delegate($sut));
+    }
+
+    public function magicCallProvider()
+    {
+        $sut = new MagicCall();
+
+        return [
+            [
+                [$sut, '__invoke'],
+                '/__invoke\(\) does not exist$/',
+            ],
+            [
+                [$sut, 'delegate'],
+                '/delegate\(\) does not exist$/',
+            ],
+            [
+                [MagicCall::class, '__invoke'],
+                '/__invoke\(\) does not exist$/',
+            ],
+            [
+                MagicCall::class.'::__invoke',
+                '/__invoke\(\) does not exist$/',
+            ],
+            [
+                [MagicCall::class, 'delegate'],
+                '/delegate\(\) does not exist$/',
+            ],
+            [
+                MagicCall::class.'::delegate',
+                '/delegate\(\) does not exist$/',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider magicCallProvider
+     */
+    public function testMagicCallShouldBeInvalid($var, $messageRegExp)
+    {
+        $this->expectException(ReflectionException::class);
+        $this->expectExceptionMessageRegExp($messageRegExp);
+        is_delegate($var);
+    }
+
+    public function testPureInvokableWithMixedRequestShouldBeInvalid()
+    {
+        $sut = new PureInvokableWithMixedRequest();
+        $this->assertSame(false, is_delegate($sut));
+        $this->assertSame(false, is_delegate([$sut, '__invoke']));
+        $this->assertSame(false, is_delegate([PureInvokableWithMixedRequest::class, '__invoke']));
+        $this->assertSame(false, is_delegate(PureInvokableWithMixedRequest::class.'::__invoke'));
+    }
+
+    public function testPureInvokableWithoutRequestShouldBeInvalid()
+    {
+        $sut = new PureInvokableWithoutRequest();
+        $this->assertSame(false, is_delegate($sut));
+        $this->assertSame(false, is_delegate([$sut, '__invoke']));
+        $this->assertSame(false, is_delegate([PureInvokableWithoutRequest::class, '__invoke']));
+        $this->assertSame(false, is_delegate(PureInvokableWithoutRequest::class.'::__invoke'));
+    }
+
+    public function testStaticDelegateWithMixedRequestShouldBeInvalid()
+    {
+        $sut = new StaticDelegateWithMixedRequest();
+        $this->assertSame(false, is_delegate([$sut, 'delegate']));
+        $this->assertSame(false, is_delegate([StaticDelegateWithMixedRequest::class, 'delegate']));
+        $this->assertSame(false, is_delegate(StaticDelegateWithMixedRequest::class.'::delegate'));
+    }
+
+    public function testStaticDelegateWithoutRequestShouldBeInvalid()
+    {
+        $sut = new StaticDelegateWithoutRequest();
+        $this->assertSame(false, is_delegate([$sut, 'delegate']));
+        $this->assertSame(false, is_delegate([StaticDelegateWithoutRequest::class, 'delegate']));
+        $this->assertSame(false, is_delegate(StaticDelegateWithoutRequest::class.'::delegate'));
+    }
+}

--- a/tests/IsDelegateValidTest.php
+++ b/tests/IsDelegateValidTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Interop\Http\Middleware;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Interop\Http\Middleware\Fixtures\Delegates\Valid\PureInvokable;
+use Interop\Http\Middleware\Fixtures\Delegates\Valid\Delegate;
+use Interop\Http\Middleware\Fixtures\Delegates\Valid\StaticDelegate;
+
+use function Interop\Http\Middleware\Fixtures\Delegates\Valid\fnDelegateFactory;
+
+class IsDelegateValidTest extends \PHPUnit_Framework_TestCase
+{
+    public function testFnDelegateShouldBeValid()
+    {
+        $this->assertSame(
+            true,
+            is_delegate('Interop\Http\Middleware\Fixtures\Delegates\Valid\fnDelegate')
+        );
+    }
+
+    public function testFnDelegateFactoryShouldBeValid()
+    {
+        $sut = fnDelegateFactory();
+        $this->assertSame(true, is_delegate($sut));
+    }
+
+    public function testPureInvokableShouldBeValid()
+    {
+        $sut = new PureInvokable();
+        $this->assertSame(true, is_delegate($sut));
+        $this->assertSame(true, is_delegate([$sut, '__invoke']));
+    }
+
+    public function testDelegateShouldBeValid()
+    {
+        $sut = new Delegate();
+        $this->assertSame(true, is_delegate($sut));
+        $this->assertSame(true, is_delegate([$sut, '__invoke']));
+    }
+
+    public function testStaticDelegateShouldBeValid()
+    {
+        $sut = new StaticDelegate();
+        $this->assertSame(true, is_delegate([$sut, 'Delegate']));
+        $this->assertSame(true, is_delegate([StaticDelegate::class, 'delegate']));
+        $this->assertSame(true, is_delegate(StaticDelegate::class.'::delegate'));
+    }
+}

--- a/tests/IsMiddlewareInvalidTest.php
+++ b/tests/IsMiddlewareInvalidTest.php
@@ -1,0 +1,182 @@
+<?php
+
+namespace Interop\Http\Middleware;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+use ReflectionException;
+use Interop\Http\Middleware\Fixtures\Middlewares\Invalid\MagicCall;
+use Interop\Http\Middleware\Fixtures\Middlewares\Invalid\PureInvokableDoublePass;
+use Interop\Http\Middleware\Fixtures\Middlewares\Invalid\PureInvokableWithDelegate;
+use Interop\Http\Middleware\Fixtures\Middlewares\Invalid\PureInvokableWithMixedRequest;
+use Interop\Http\Middleware\Fixtures\Middlewares\Invalid\PureInvokableWithoutDelegate;
+use Interop\Http\Middleware\Fixtures\Middlewares\Invalid\StaticMiddlewareDoublePass;
+use Interop\Http\Middleware\Fixtures\Middlewares\Invalid\StaticMiddlewareWithMixedRequest;
+use Interop\Http\Middleware\Fixtures\Middlewares\Invalid\StaticMiddlewareWithoutDelegate;
+
+use function Interop\Http\Middleware\Fixtures\Middlewares\Invalid\fnDoublePassFactory;
+use function Interop\Http\Middleware\Fixtures\Middlewares\Invalid\fnWithDelegateFactory;
+use function Interop\Http\Middleware\Fixtures\Middlewares\Invalid\fnWithMixedRequestFactory;
+use function Interop\Http\Middleware\Fixtures\Middlewares\Invalid\fnWithoutDelegateFactory;
+
+class IsMiddlewareInvalidTest extends \PHPUnit_Framework_TestCase
+{
+    public function testFnDoublePassShouldBeInvalid()
+    {
+        $this->assertSame(
+            false,
+            is_server_middleware('Interop\Http\Middleware\Fixtures\Delegates\Invalid\fnDoublePass')
+        );
+    }
+
+    public function testFnDoublePassFactoryShouldBeInvalid()
+    {
+        $sut = fnDoublePassFactory();
+        $this->assertSame(false, is_server_middleware($sut));
+    }
+
+    public function testFnWithDelegateShouldBeInvalid()
+    {
+        $this->assertSame(
+            false,
+            is_server_middleware('Interop\Http\Middleware\Fixtures\Delegates\Invalid\fnWithDelegate')
+        );
+    }
+
+    public function testFnWithDelegateFactoryShouldBeInvalid()
+    {
+        $sut = fnWithDelegateFactory();
+        $this->assertSame(false, is_server_middleware($sut));
+    }
+
+    public function testFnWithMixedRequestShouldBeInvalid()
+    {
+        $this->assertSame(
+            false,
+            is_server_middleware('Interop\Http\Middleware\Fixtures\Delegates\Invalid\fnWithMixedRequest')
+        );
+    }
+
+    public function testFnWithMixedRequestFactoryShouldBeInvalid()
+    {
+        $sut = fnWithMixedRequestFactory();
+        $this->assertSame(false, is_server_middleware($sut));
+    }
+
+    public function testFnWithoutDelegateShouldBeInvalid()
+    {
+        $this->assertSame(
+            false,
+            is_server_middleware('Interop\Http\Middleware\Fixtures\Delegates\Invalid\fnWithoutDelegate')
+        );
+    }
+
+    public function testFnWithoutDelegateFactoryShouldBeInvalid()
+    {
+        $sut = fnWithoutDelegateFactory();
+        $this->assertSame(false, is_server_middleware($sut));
+    }
+
+    public function magicCallProvider()
+    {
+        $sut = new MagicCall();
+
+        return [
+            [
+                [$sut, '__invoke'],
+                '/__invoke\(\) does not exist$/',
+            ],
+            [
+                [$sut, 'middleware'],
+                '/middleware\(\) does not exist$/',
+            ],
+            [
+                [MagicCall::class, '__invoke'],
+                '/__invoke\(\) does not exist$/',
+            ],
+            [
+                MagicCall::class.'::__invoke',
+                '/__invoke\(\) does not exist$/',
+            ],
+            [
+                [MagicCall::class, 'middleware'],
+                '/middleware\(\) does not exist$/',
+            ],
+            [
+                MagicCall::class.'::middleware',
+                '/middleware\(\) does not exist$/',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider magicCallProvider
+     */
+    public function testMagicCallShouldBeInvalid($var, $messageRegExp)
+    {
+        $this->expectException(ReflectionException::class);
+        $this->expectExceptionMessageRegExp($messageRegExp);
+        is_server_middleware($var);
+    }
+
+    public function testPureInvokableDoublePassShouldBeInvalid()
+    {
+        $sut = new PureInvokableDoublePass();
+        $this->assertSame(false, is_server_middleware($sut));
+        $this->assertSame(false, is_server_middleware([$sut, '__invoke']));
+        $this->assertSame(false, is_server_middleware([PureInvokableDoublePass::class, '__invoke']));
+        $this->assertSame(false, is_server_middleware(PureInvokableDoublePass::class.'::__invoke'));
+    }
+
+    public function testPureInvokableWithDelegateShouldBeInvalid()
+    {
+        $sut = new PureInvokableWithDelegate();
+        $this->assertSame(false, is_server_middleware($sut));
+        $this->assertSame(false, is_server_middleware([$sut, '__invoke']));
+        $this->assertSame(false, is_server_middleware([PureInvokableWithDelegate::class, '__invoke']));
+        $this->assertSame(false, is_server_middleware(PureInvokableWithDelegate::class.'::__invoke'));
+    }
+
+    public function testPureInvokableWithMixedRequestShouldBeInvalid()
+    {
+        $sut = new PureInvokableWithMixedRequest();
+        $this->assertSame(false, is_server_middleware($sut));
+        $this->assertSame(false, is_server_middleware([$sut, '__invoke']));
+        $this->assertSame(false, is_server_middleware([PureInvokableWithMixedRequest::class, '__invoke']));
+        $this->assertSame(false, is_server_middleware(PureInvokableWithMixedRequest::class.'::__invoke'));
+    }
+
+    public function testPureInvokableWithoutDelegateShouldBeInvalid()
+    {
+        $sut = new PureInvokableWithoutDelegate();
+        $this->assertSame(false, is_server_middleware($sut));
+        $this->assertSame(false, is_server_middleware([$sut, '__invoke']));
+        $this->assertSame(false, is_server_middleware([PureInvokableWithoutDelegate::class, '__invoke']));
+        $this->assertSame(false, is_server_middleware(PureInvokableWithoutDelegate::class.'::__invoke'));
+    }
+
+    public function testStaticMiddlewareDoublePassShouldBeInvalid()
+    {
+        $sut = new StaticMiddlewareDoublePass();
+        $this->assertSame(false, is_server_middleware([$sut, 'delegate']));
+        $this->assertSame(false, is_server_middleware([StaticMiddlewareDoublePass::class, 'delegate']));
+        $this->assertSame(false, is_server_middleware(StaticMiddlewareDoublePass::class.'::delegate'));
+    }
+
+    public function testStaticMiddlewareWithMixedRequestShouldBeInvalid()
+    {
+        $sut = new StaticMiddlewareWithMixedRequest();
+        $this->assertSame(false, is_server_middleware([$sut, 'delegate']));
+        $this->assertSame(false, is_server_middleware([StaticMiddlewareDoublePass::class, 'delegate']));
+        $this->assertSame(false, is_server_middleware(StaticMiddlewareDoublePass::class.'::delegate'));
+    }
+
+    public function testStaticMiddlewareWithoutDelegateShouldBeInvalid()
+    {
+        $sut = new StaticMiddlewareWithoutDelegate();
+        $this->assertSame(false, is_server_middleware([$sut, 'delegate']));
+        $this->assertSame(false, is_server_middleware([StaticMiddlewareDoublePass::class, 'delegate']));
+        $this->assertSame(false, is_server_middleware(StaticMiddlewareDoublePass::class.'::delegate'));
+    }
+}

--- a/tests/IsMiddlewareValidTest.php
+++ b/tests/IsMiddlewareValidTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Interop\Http\Middleware;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+use Interop\Http\Middleware\Fixtures\Middlewares\Valid\Middleware;
+use Interop\Http\Middleware\Fixtures\Middlewares\Valid\PureInvokable;
+use Interop\Http\Middleware\Fixtures\Middlewares\Valid\StaticMiddleware;
+
+use function Interop\Http\Middleware\Fixtures\Middlewares\Valid\fnMiddlewareFactory;
+
+class IsMiddlewareValidTest extends \PHPUnit_Framework_TestCase
+{
+    public function testFnMiddlewareShouldBeValid()
+    {
+        $this->assertSame(
+            true,
+            is_server_middleware('Interop\Http\Middleware\Fixtures\Middlewares\Valid\fnMiddleware')
+        );
+    }
+
+    public function testFnMiddlewareFactoryShouldBeValid()
+    {
+        $sut = fnMiddlewareFactory();
+        $this->assertSame(true, is_server_middleware($sut));
+    }
+
+    public function testMiddlewareShouldBeValid()
+    {
+        $sut = new Middleware();
+        $this->assertSame(true, is_server_middleware($sut));
+        $this->assertSame(true, is_server_middleware([$sut, '__invoke']));
+    }
+
+    public function testPureInvokableWithCallableShouldBeValid()
+    {
+        $sut = new PureInvokable();
+        $this->assertSame(true, is_server_middleware($sut));
+        $this->assertSame(true, is_server_middleware([$sut, '__invoke']));
+    }
+
+    public function testStaticMiddlewareShouldBeValid()
+    {
+        $sut = new StaticMiddleware();
+        $this->assertSame(true, is_server_middleware([$sut, 'middleware']));
+        $this->assertSame(true, is_server_middleware([StaticMiddleware::class, 'middleware']));
+        $this->assertSame(true, is_server_middleware(StaticMiddleware::class.'::middleware'));
+    }
+}

--- a/tests/smoke-test.php
+++ b/tests/smoke-test.php
@@ -1,0 +1,72 @@
+#!/usr/bin/env php
+<?php
+
+namespace SmokeTest;
+
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+require __DIR__.'/../vendor/autoload.php';
+
+/**
+ * @todo find PHP 5.3+ test harness
+ */
+class TapProducer
+{
+    private $planned = 0;
+    private $tests;
+
+    public function add($descr, $test) {
+        $this->tests[$descr] = $test;
+        $this->planned++;
+    }
+
+    function run() {
+        $planned = $this->planned;
+        $runned = 0;
+        $failed = 0;
+
+        echo '1..'.$planned.PHP_EOL;
+
+        foreach($this->tests as $descr => $test) {
+            if ($test()) {
+                $result = 'ok';
+            } else {
+                $result = 'not ok';
+                $failed++;
+            }
+            $runned++;
+            echo $result.' '.$runned.' - '.$descr.PHP_EOL;
+        }
+
+        return $failed;
+    }
+}
+
+$t = new TapProducer();
+
+$t->add('delegate', function () {
+    return true === \Interop\Http\Middleware\is_delegate(function (RequestInterface $request) {
+        return null;
+    });
+});
+
+$t->add('not delegate', function () {
+    return false === \Interop\Http\Middleware\is_delegate(function ($request) {
+        return null;
+    });
+});
+
+$t->add('middleware', function () {
+    return true === \Interop\Http\Middleware\is_server_middleware(function (ServerRequestInterface $request, callable $delegate) {
+        return $delegate($request);
+    });
+});
+
+$t->add('non middleware', function () {
+    return false === \Interop\Http\Middleware\is_server_middleware(function ($request, $delegate) {
+        return $delegate($request);
+    });
+});
+
+exit($t->run());


### PR DESCRIPTION
This is not a serious PR, it is only a proof of concept – I've just found some time to investigate the idea of describing middlewares and delegates by `callable` **and** `interface` and what we might lose.

I hope this stuff will help to pursue the debate about that topic, so everybody can rethink his stand based on a more concrete level.

## If you just chimed in

#37 is about the following change:
```diff
interface DelegateInterface
{
-    public function process(RequestInterface $request);
+    public function __invoke(RequestInterface $request);
}

interface ServerMiddlewareInterface
{
-    public function process(ServerRequestInterface $request, DelegateInterface $delegate);
+    public function __invoke(ServerRequestInterface $request, callable $delegate);
}
```

_I know, we are discussing the `process` to `__invoke` change only for the `DelegateInterface` at #37 yet, if that bothers you, then just read over the `ServerMiddlewareInterface::__invoke` parts._

**The idea:** The interfaces are used to describe the signature and the behavior which the `callables` must fulfill. But moreover, the interfaces MAY be used by implementers, hence they get code completion and static type analysis, at least to some extend.

## Possible Drawbacks 

BCs and migration problems about `__invoke` were discussed in passionate debates. The main problem: Frameworks may already have introduced interfaces with `__invoke` but with different signature/contract, notably [Zend\Stratigility](https://github.com/zendframework/zend-stratigility/blob/f0f1c6b0248d0218172b0da067f17c9bad6a494b/src/MiddlewareInterface.php#L32-L57).

Two ideas alleviate that problem:
1. as we switch to `callable`s, implementers can create a new PSR compatible middleware method:
```php
class Middleware implements \Some\Other\MiddlewareInterface
{
    // legacy middleware
    public function __invoke(ServerRequestInterface $request, ResponseInterface $response, callable $out = null) {…}

    // PSR middleware 
    public function process(ServerRequestInterface $request, DelegateInterface $delegate) {…}
}

// and use it:
$middleware = new Middleware();
$app->pipe('/', [$middleware, 'process']);
``` 
2. Frameworks wich suffer from BC issues may check against the signature at *run-time*.

## About this PR

Personally, I wasn't sure if type checking at run-time is powerful enough at PHP 5.4+ for our purposes.
So I gave it a shot and created two functions:
```php
namespace Interop\Http\Middleware;

/**
 * Verify that the contents of a variable can be called as a delegate.
 *
 * @param mixed $var The value to check
 *
 * @return bool Returns TRUE if var is a delegate, FALSE otherwise.
 * @throws ReflectionException if the function does not exist.
 */
function is_delegate($var) {…}

/**
 * Verify that the contents of a variable can be called as a middleware.
 *
 * @param mixed $var The value to check
 *
 * @return bool Returns TRUE if var is a middleware, FALSE otherwise.
 * @throws ReflectionException if the function does not exist.
 */
function is_server_middleware($var) {…}
```

I believe they are thoroughly tested: [![Build Status](https://travis-ci.org/schnittstabil/http-middleware.svg?branch=callable)](https://travis-ci.org/schnittstabil/http-middleware) I have written many delegate and middleware implementations only to document which delegates/middlewares are considered as valid and which are not. You may scan over the `tests/Fixtures/*/{Valid,Invalid}` directories – in my opinion they all work as expected.

The most interesting observations I've made:
* [`tests/Fixtures/Delegates/Invalid/MagicCall.php`](https://github.com/http-interop/http-middleware/pull/39/files#diff-04838e5850f0338ca20306f965ce6789) shows that `__call` cannot be verified – very obvious
* [`tests/Fixtures/Middlewares/Invalid/PureInvokableWithDelegate.php`](https://github.com/http-interop/http-middleware/pull/39/files#diff-4001c55f8ae01744053b26f710fc9e86) shows that we lose the ability to have `(ServerRequestInterface $request, DelegateInterface $delegate)` middlewares – we may allow that as well, but that's not how interfaces work and would lead to many problems.
* [`tests/Fixtures/Delegates/Valid/functions.php`](https://github.com/http-interop/http-middleware/pull/39/files#diff-72d6d8caa36ea2af6adf0cea2633ad43) shows that linters and IDEs will annoy implementers with *unused formal parameters* warnings if they don't use all parameters, notably PHPMD. Btw, it is currently not possible to suppress the warning in that file, which is related to https://github.com/phpmd/phpmd/issues/337.
* and most important: [`tests/Fixtures/Middlewares/Invalid/PureInvokableDoublePass.php`](https://github.com/http-interop/http-middleware/pull/39/files#diff-27b1cbb0b9a830bf8611472d89243cd4) and many other tests show that we can safely distinguish double-pass from single-pass.

I'm willing to transfer this stuff to http-interop and waive all copyright rights, so frameworks can safely use it or could create their own implementations based on this work. However, I would suggest to create a new project for that: PHP may eventually introduce new types of `callables` and after all it is still in an early stage…

Whether we chose the `callables+interface` style for middlewares or delegates or both or not at all, I'll be fine with it – As you perhaps know, the contract (the naming and the descriptions in the comments) is much more important to me…

Best regards
Michael