### PR TITLE
Practical Discussion about callable Delegates

### DIFF
--- a/src/DelegateInterface.php
+++ b/src/DelegateInterface.php
@@ -14,5 +14,5 @@ interface DelegateInterface
      *
      * @return ResponseInterface
      */
-    public function process(RequestInterface $request);
+    public function __invoke(RequestInterface $request);
 }

--- a/src/MiddlewareInterface.php
+++ b/src/MiddlewareInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Interop\Http\Middleware;
+
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+interface MiddlewareInterface
+{
+    /**
+     * Process an incoming request and return a response, optionally delegating
+     * to the next middleware component to create the response.
+     *
+     * @param RequestInterface           $request
+     * @param DelegateInterface|callable $delegate
+     *
+     * @return ResponseInterface
+     */
+    public function process(RequestInterface $request, callable $delegate);
+}

--- a/src/ServerMiddlewareInterface.php
+++ b/src/ServerMiddlewareInterface.php
@@ -11,10 +11,10 @@ interface ServerMiddlewareInterface
      * Process an incoming server request and return a response, optionally delegating
      * to the next middleware component to create the response.
      *
-     * @param ServerRequestInterface $request
-     * @param DelegateInterface $delegate
+     * @param ServerRequestInterface     $request
+     * @param DelegateInterface|callable $delegate
      *
      * @return ResponseInterface
      */
-    public function process(ServerRequestInterface $request, DelegateInterface $delegate);
+    public function process(ServerRequestInterface $request, callable $delegate);
 }


### PR DESCRIPTION
To put issue #37 in a more practical context, I have started this `discussion` branch, along with a matching [middleman discussion-branch](https://github.com/mindplay-dk/middleman/tree/discussion) which has been updated to match those changes.

Per the commit-log so far, I have made two changes:

> in `ServerMiddlewareInterface`, allow `callable` as `$delegate` in middleware-signature, using a static type-hint of callable. In `DelegateInterface`, using the method-name `__invoke()` then becomes necessary, so this has been changed.

> since the removal of `MiddlewareInterface`, we decided to use a type-hint of `RequestInterface` in `DelegateInterface`, for future compatibility with non-server-middleware - I think there is no longer any reason to exclude `MiddlewareInterface` from the standard. This will also align better with the de-facto standard.

Per the [test-suite](https://github.com/mindplay-dk/middleman/blob/discussion/test/test.php), this all works as expected - it's simpler than previously, and inspections in Php Storm seem to make sense.

The only thing I would do differently, if it was possible, is have `ServerMiddlewareInterface` extend `MiddlewareInterface`, but we've explored that, and it's not really possible. Having to select and implement either one or the other appears to make sense though - your middleware will effectively support either `RequestInterface|ServerRequestInterface` for client/server-middleware, *or* `ServerRequestInterface` for server-only middleware.
