### PR TITLE
Remove recusive middleware stack argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,9 +285,7 @@ additional information._
 Both the middleware and delegate interface define a `process` method to prevent
 misuse of middleware as delegates.
 
-If a middleware was used as a delegate the entire middleware stack would end up
-recursive, instead of piped. The implementation of delegate should be defined
-within middleware dispatching systems.
+The implementation of delegate should be defined within middleware dispatching systems.
 
 6. People
 ---------


### PR DESCRIPTION
The recursion argument is flawed, see https://github.com/http-interop/http-middleware/pull/41#issuecomment-263915893 and https://github.com/http-interop/http-middleware/pull/24#issuecomment-261727171

**tl;tr** Recursion itself is not bad, only endless loops are; furthermore some weird tricks are needed to achieve that – Nobody can protect stupid people to do stupid things.
