### PR TITLE
Rename DelegateInterface::process to RequestHandlerInterface::__invoke

### DIFF
--- a/src/RequestHandlerInterface.php
+++ b/src/RequestHandlerInterface.php
@@ -5,14 +5,14 @@ namespace Interop\Http\Middleware;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
-interface DelegateInterface
+interface RequestHandlerInterface
 {
     /**
-     * Dispatch the next available middleware and return the response.
+     * Process an incoming server request and return the response.
      *
      * @param ServerRequestInterface $request
      *
      * @return ResponseInterface
      */
-    public function process(ServerRequestInterface $request);
+    public function __invoke(ServerRequestInterface $request);
 }

--- a/src/ServerMiddlewareInterface.php
+++ b/src/ServerMiddlewareInterface.php
@@ -9,12 +9,12 @@ interface ServerMiddlewareInterface
 {
     /**
      * Process an incoming server request and return a response, optionally delegating
-     * to the next middleware component to create the response.
+     * to the next request handler to create the response.
      *
      * @param ServerRequestInterface $request
-     * @param DelegateInterface $delegate
+     * @param RequestHandlerInterface $next
      *
      * @return ResponseInterface
      */
-    public function process(ServerRequestInterface $request, DelegateInterface $delegate);
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $next);
 }


### PR DESCRIPTION
I've encountered many problems with the current `DelegateInterface` and its related contract within my projects. I have thoroughly reviewed all debates about the change I'm proposing with this PR and I do not see any solid technical reason against it. This proposal is about contracts and the big picture, hence, please give it real a chance.


The new versions:
```php
namespace Interop\Http\Middleware;

interface RequestHandlerInterface
{
    /**
     * Process an incoming server request and return the response.
     *
     * @param ServerRequestInterface $request
     *
     * @return ResponseInterface
     */
    public function __invoke(ServerRequestInterface $request);
}

interface ServerMiddlewareInterface
{
    /**
     * Process an incoming server request and return a response, optionally delegating
     * to the next request handler to create the response.
     *
     * @param ServerRequestInterface $request
     * @param RequestHandlerInterface $next
     *
     * @return ResponseInterface
     */
    public function process(ServerRequestInterface $request, RequestHandlerInterface $next);
}
```

# I. What is wrong with `DelegateInterface`?
## 1. Middlewares cannot be reused w/o a middleware container.
<details>

I'm not the only one struggling with this problem, afaik @mindplay-dk (#37) is suffering from this too. Sometimes we want to call a single middleware, e.g.

```php
$csrfMiddleware = new CsrfMiddleware();

$response = $csrfMiddleware->process($request, new class() implements DelegateInterface {
    public function process(ServerRequestInterface $request) {
        return new Response(200);
    }
});
```

While this is technical possible, the contracts prohibit that, they are as follows:
```php
interface DelegateInterface
{
    /**
     * Dispatch the next available middleware and return the response.
     */
    public function process(ServerRequestInterface $request);
}

interface ServerMiddlewareInterface
 {
    /**
     * …, optionally delegating to the next middleware component to create the response.
     */
    public function process(ServerRequestInterface $request, DelegateInterface $delegate);
```

The `DelegateInterface` instance above does not *dispatch the next available middleware*, the instance does not know if there is any *next available middleware*. @mindplay-dk dissented this point of view at https://github.com/http-interop/http-middleware/pull/29#issuecomment-260746270:

>  the role of even a simple function consisting of `return new Response()` is still _acting_ as middleware in it's relation to the middleware component that calls it.

To be honest, this looks like we are forcing the world to fit the spec, instead of creating a model based on reality:
```php
$d = new class implements DelegateInterface {…};
var_dump($d instanceof DelegateInterface); // => true
var_dump($d instanceof ServerMiddlewareInterface); // => false
```

Hence, PHP says "no"! The class above is a delegate, not a middleware.

Furthermore this point of view conflicts with the idea of *middleware container delegate* (@weierophinney at https://github.com/http-interop/http-middleware/pull/29#issuecomment-260466313):

> The delegate is used to manage a stack, queue, collection, whatever, of middleware, but is not itself middleware. The idea when calling it from within middleware is to see if **some other middleware** can produce a response. [emphasis added]

Therefore, to be on the safe side, we must use a stack/pipe e.g.:
```php
$csrfMiddleware = new CsrfMiddleware();

$pipe = new \Equip\Dispatch\MiddlewarePipe($csrfMiddleware);

// Default handler for end of pipe
$default = function (RequestInterface $request) {
    return new Response();
};

$response = $pipe->dispatch($request, $default);
```
</details>

## 2. Current PSR-15 middleware containers already infringe the current contracts.
<details>

If we look at the `Equip\Dispatch\MiddlewarePipe` example above, we see a default handler, which is an anonymous function (closure), needed to dispatch the request. The [`MiddlewarePipe::dispatch`](https://github.com/equip/dispatch/blob/master/src/MiddlewarePipe.php#L57-L62) looks like this:

```php
public function dispatch(ServerRequestInterface $request, callable $default)
{
    $delegate = new Delegate($this->middleware, $default);
    // …
}
```

Thus the default handler is wrapped into a delegate adapter. But, for the same reasons as in _I. 1._, the `$delegate` cannot fulfill the contracts. Equip Dispatch is by far not the only project doing that, all current PSR-15 frameworks (I'm aware of) wrap anonymous functions (closures) into `DelegateInterface` adapters today and infringe the contract in that way.
</details>

## 3. The `DelegateInterface` contract is too vague.
<details>

According to the phpdoc:
> Dispatch the next **available** middleware and return the response. [emphasis added]

However, what happens when there is no next middleware *available*?

Does `$delegate->process(…)`:
1. Throws an exception?
2. Returns an empty response?
3. Returns `null`?

In my opinion the middleware should not care at all. "available middleware" passes the responsibility to care about these questions to the middleware – that is obviously undesirable.

</details>

## 4. The `DelegateInterface` contract is too concrete.
<details>

According to the phpdoc:
> **Dispatch** the next available **middleware** and return the response. [emphasis added]

Do a middleware need to know that a *middleware* will be dispatched? Beside that this is not true in all cases (see _I. 2._), why should a middleware care?

Furthermore, why should a middleware care that it deals with a delegate? From the middleware point of view, it does not matter. The only important information is "**Process a request and return the response.**". That's all, because the `ServerMiddlewareInterface` contract already states:

> … **to the next** middleware component[thingy in the queue] to create the response. [emphasis added]
</details>

## 5. Middlewares have to be aware that they are executed within a container.
<details>

While it is true in most use cases (except the one in _I. 1._) that a middleware is executed within a container, we do not have one single use-case so far where this is important. Let's face it: almost all middleware frameworks use `callable` and are happy without that information.

Hence, the knowledge about: *`$delegate` is a delegate of a container* is useless.
</details>

## 6. For experienced middleware developers the wording of the `ServerMiddlewareInterface` contract is irritating.
<details>

According to the phpdoc:
> … optionally **delegating** to the next middleware component to create the response.

_delegating_ is a clearly a verb and as a middleware implementer who has used multiple middleware frameworks, I expect a `callable` or _`__invokable`_ thingy if I read `$delegate` afterwards. But, surprisingly *delegate* is used as a noun at `@param DelegateInterface $delegate`. Thus we have this weird situation:

```
     $delegate->process(…);
         |         |
         |         \------  the contract uses "delegating" (verb!) for this method
         |
         \---------------- the phpdoc uses "delegate" (noun!) for this object
```
</details>

## 7. Middleware delegates cannot be reused.
<details>
This one annoys me the most, because I have too many use-cases of this kind.

Please note the namespace of the the proposed request handler (i.e. `Interop\Http\Middleware`). Therefore, the request handler is not an arbitrary _request handler_, it is a _**middleware** request handler_.

There are many candidates of shareable _delegates_ in the world of middlewares:
* Default/final handlers which throw errors.
* Default/final handlers which return an empty response.
* Default/final handlers which return domain specific responses.
* Stacks (see #35)
* …

They all share the same method signature: `(ServerRequestInterface $request) : ResponseInterface`, but most of them cannot fulfill the `DelegateInterface` contract (see _I. 1._ for details). The `RequestHandlerInterface` name and the new contracts solve that and lead to interop on the _middleware delegate_ level.
</details>

# II. Why `RequestHandlerInterface`?

Just because (almost) every PHP developer can instantly grasp the idea – in contrast to `FrameInterface` and `DelegateInterface`.

## Why `RequestHandlerInterface::__invoke`?
### 1. `callable` does not provide enough _type-safety_ etc.
<details>

Honestly, I'm not the right person to explain that [point of view](https://github.com/http-interop/http-middleware/issues/37#issuecomment-265300033). I've implemented sophisticated type-systems (e.g. [Linear types and non-size-increasing polynomial time computation](https://www.tcs.ifi.lmu.de/mitarbeiter/martin-hofmann/publikationen-pdfs/j17-lineartypesnonsizeincerasing.pdf)) and I've created a type-system for a DSL in my master thesis. And I can assure you, I love strictly typing and e.g. [Agda](https://github.com/agda/agda) – in theory. But, PHP is practice, which I professionally use since 2000 (v4.0.2 or so), and it seems that PHP developers cannot sleep well without a more strictly-typed version.
</details>

### 2. Experienced middleware developers expect a `callable` or at least a _`__invokable`_.
<details>

I hope, at least this is obvious. Almost all middlewares use a `callable` type-hint, using an `__invoke` interface relieve pain of loosing `callable` and writing cumbersome code.
</details>

### 3. Libraries and frameworks already supports this interface
<details>

`RequestHandlerInterface::__invoke(ServerRequestInterface $request)` is general enough to reuse it already today with non-PSR-15 compatible libraries. I've already showed that with the `Aura.Router` at https://github.com/http-interop/http-middleware/pull/39#issuecomment-263134031.

In contrast, `DelegateInterface::process/dispatch/etc` forces us to write stupid Adapters, e.g. with Slim:
```php
$contactStack = new ContactStack();
$app = new Slim\App();

// instead of:
$app->get('/', $contactStack);

// we have to write a dump adapter function:
$app->get('/', function ($request) use ($contactStack) {
    return $contactStack->process($request);
};
```

The problem with these adapters: they provide zero value, are not type-safe and are annoying to write and test.
</details>

## Why `$next`?
<details>

It does not make a real difference, the new `ServerMiddlewareInterface` contract:
> … optionally delegating to the next request handler to create the response.

Thus, we can also use:
1. `$delegate`
2. `$nextResponseHandler`
3. `$nextHandler`
4.  …

I don't really care, but all double-pass implementations I'm aware of, use `$next`. And I do not want to confuse them unnecessarily.
</details>

# III. Arguments against `::__invoke`

## 1. `RequestHandlerInterface::__invoke` does not conflict with `ServerMiddlewareInterface::process`
<details>

The argument is originally about the `callable` type-hint and states the following:
> Making delegates callable without making middleware callable would allow people to implement both middleware and delegate interfaces in the same class, which is definitely not correct.

Obviously, this applies to `__invoke` interfaces as well. But the inheritance hierarchy and interface were never created to prevent that – The opposite is the case, they provide definitions of methods which objects agree on in order to **cooperate**. If we preventing cooperation by the same name on purpose, then we abuse the type-system in my opinion.

Moreover, I gave a realistic example of middlewares which can act as delegates as well at https://github.com/http-interop/http-middleware/pull/41#issuecomment-263969406. Nobody, argued against it, therefore the argument is an untenable assertion in my opion.
</details>

## 2. `::__invoke` can be type hinted as `callable`
<details>

The [argument of the current META](https://github.com/http-interop/http-middleware/tree/fd47985af5ce4de141534bbc1f42978686351805#why-doesnt-middleware-use-__invoke) is originally about the `callable` middlewares and states the following:

> In addition, classes that define `__invoke` can be type hinted as `callable`, which results in less strict typing. This is generally undesirable, especially when the `__invoke` method uses strict typing.

On the first glance, this applies to `RequestHandlerInterface::__invoke` as well. Although, I disagree with the quote, it is not applicable here: with this proposal we do not encourage a `callable` type-hint, e.g.:

```php
$next = function(ServerRequestInterface $request) {…};

var_dump($next instanceof RequestHandlerInterface); // => false
```

From the PSR point of view an anonymous function etc. is not a valid `RequestHandlerInterface` instance.
</details>

## 3. `::__invoke` conflicts with double-pass (`callable $next`)
<details>

See details at https://github.com/http-interop/http-middleware/pull/39#issuecomment-265266694.

The argument is in my opinion really Stratigility specific. It is about `callable` delegates in Stratigility etc.

> [Simplified] With a different method name we make migration easier.

This debate could already end here, because @weierophinney already stated:

> These are all solvable, but they're far easier to solve when the methods *differ*.



But okay, @shadowhand claimed I would [ignore arguments](https://github.com/http-interop/http-middleware/issues/43#issuecomment-266212719), lets take a look at [`Zend\Stratigility\Next`](https://github.com/zendframework/zend-stratigility/blob/b12bae3dab179d4ffb8af4c5dbfa66fbfeef3c38/src/Next.php#L24):

```php
class Next implements DelegateInterface
{
    public function __invoke(ServerRequestInterface $request, ResponseInterface $response, $err = null) {…}

    public function process(RequestInterface $request) {…}
}
```

Obviously, using the [decorator pattern](https://en.wikipedia.org/wiki/Decorator_pattern) to _add single-pass behavior_  is based on the wrong assumption that we want/need to _add_ something. What we really want to accomplish is this: the legacy implementation should work with the new PSR-15 without modifying source code; and this can be simply done via the [adapter pattern:
](https://en.wikipedia.org/wiki/Adapter_pattern)

```php
// simplified:
if ($middleware instanceof ServerMiddlewareInterface) {
    return $middleware->process($request, new PsrAdapter(new Next(…));
} else {
    return $middleware($request, $response, new Next(…));
}
```
</details>

## 4. `::__invoke` cannot be used for other means.

<details>

The argument is originally about the middlewares, but also applicable to request handlers:
> However, this also prevents any implementing middleware from using `__invoke` for other means.

Obviously, the same holds for `dispatch` and `process`, as long as we not choose a uuid or similar we cannot solve that:

```php
// I'm pretty sure, this method name is not already taken:
$delegate->f892336f82044c759f49c78d834cff3a($request);
```
</details>

## 5. Mocking issues with `::__invoke`

<details>

> I remember issues when mocking (with prophecy) and trying to test __invokable's response/result

That do not really matter to this discussion, but afaik, it is already solved: https://github.com/phpspec/prophecy/issues/205
</details>

## 6. The role the object plays in the application

<details>

Thanks to @weierophinney, about having different method names:
> This has been listed as undesirable, […] because it makes it more confusing for a consumer to know what role the object plays in the application.

`RequestHandlerInterface` makes the situation even worse: Do I want a middleware or a request handler? What are the pros and cons? In my opinion PSR-15 cannot and should not answer this question. It is about personal taste and depends on the concrete framework.
For example:
* **Framework A:** An action/controller/… is a request handler and we inject a PSR-17 Factory via its constructor.
* **Framework B:** An action/controller/… is a middleware and response creation is done via calling `$next`.
</details>

---

All other arguments I've found are about `callable` type-hints and/or middlewares and cannot be applied to this proposal in my opinion. But maybe I missed one, then please leave a comment.

---

**History:**

* 2016-12-17: Added: _III. 6. The role the object plays in the application_
