### PR TITLE
Change namespace

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "http-interop/http-middleware",
-    "description": "Common interface for HTTP middleware",
+    "description": "Common interface for HTTP server-side middleware",
     "keywords": [
         "psr",
         "psr-7",

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     },
     "autoload": {
         "psr-4": {
-            "Interop\\Http\\Middleware\\": "src/"
+            "Interop\\Http\\ServerMiddleware\\": "src/"
         }
     },
     "extra": {

--- a/src/DelegateInterface.php
+++ b/src/DelegateInterface.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Interop\Http\Middleware;
+namespace Interop\Http\ServerMiddleware;
 
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;

--- a/src/MiddlewareInterface.php
+++ b/src/MiddlewareInterface.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace Interop\Http\Middleware;
+namespace Interop\Http\ServerMiddleware;
 
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
-interface ServerMiddlewareInterface
+interface MiddlewareInterface
 {
     /**
      * Process an incoming server request and return a response, optionally delegating


### PR DESCRIPTION
Closes #47.

Option one seems most popular:
> Rename the namespace to `Psr\Http\ServerMiddleware`, and rename the `ServerMiddlewareInterface` to `MiddlewareInterface`.