### PR TITLE
Fix phpdocs according to README

### DIFF
--- a/src/DelegateInterface.php
+++ b/src/DelegateInterface.php
@@ -8,7 +8,7 @@ use Psr\Http\Message\ServerRequestInterface;
 interface DelegateInterface
 {
     /**
-     * Dispatch the next available middleware and return the response.
+     * Process an incoming server request and return the response.
      *
      * @param ServerRequestInterface $request
      *

--- a/src/MiddlewareInterface.php
+++ b/src/MiddlewareInterface.php
@@ -9,7 +9,7 @@ interface MiddlewareInterface
 {
     /**
      * Process an incoming server request and return a response, optionally delegating
-     * to the next middleware component to create the response.
+     * to the next request processor to create the response.
      *
      * @param ServerRequestInterface $request
      * @param DelegateInterface $delegate


### PR DESCRIPTION
Form the [current `README.md`](https://github.com/http-interop/http-middleware/tree/cff4fb65317875b2bccbb6b7b22eec18b5a96f04)
> ### 3.2 Non-Goals
> * Attempting to define how middleware is dispatched.
> ### 5.2 Delegate Design
>
> The `DelegateInterface` defines a single method that accepts a request and
returns a response. The delegate interface must be implemented by any middleware
dispatcher that uses middleware implementing `ServerMiddlewareInterface`.

Obviously, dispatching a middleware does not necessarily implies the existence of a _next available middleware_ or a _next middleware component_. There are too many real-world use-cases where we want to dispatch only one single middleware; hence, sticking to the current phpdoc wording would make PSR-15 less useful and does not reflect the point of view of the `README.md`.

Moreover PSR-15 should focus on interop of middlewares, the existence of additional middlewares in some frameworks is therefore out of scope. A middleware should only be aware of _sitting_ between a request and a response. Using the [StackPHP](http://stackphp.com) picture:

![stackphp-lambda-middleware](https://cloud.githubusercontent.com/assets/6059032/21763008/f63bf310-d65b-11e6-8a9c-c195b284e24f.png)

### Why _Process_ and not _Dispatch_ at `DelegateInterface`?

This is due to the fact, that we currently have `DelegateInterface::process` and not `DelegateInterface::dispatch`.

### Why request _processor_?

This is also due to the fact, that we currently have `DelegateInterface::process` and not `DelegateInterface::dispatch` or `DelegateInterface::handle` – In my opinion, _request **handler**_ sounds much better and is more common, but there is no reason to introduce another technical term. Furthermore, obviously, a standard should use as few technical terms as possible to not confuse implementers.