### PR TITLE
Remove non-sound "__invoke can be type hinted as callable" reasoning

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,10 +236,6 @@ request and a delegate and must return a response. The middleware may:
 Doing so would conflict with existing middleware that implements the double-pass
 approach and may want to implement the middleware interface.
 
-In addition, classes that define `__invoke` can be type hinted as `callable`,
-which results in less strict typing. This is generally undesirable, especially
-when the `__invoke` method uses strict typing.
-
 #### Why is a server request required?
 
 To make it clear that the middleware can only be used in a synchronous, server


### PR DESCRIPTION
This is not about pro/contra `__invoke`.

The issue here is: the reasoning is not sound – @shadowhand if you believe the reasoning contains anything valid, then you have to clarify/rewrite that paragraph, the current version seems to be just an (unproven) opinion.

#### Explanation

If we apply the same reasoning to the proposed interfaces, then we see that reasoning itself is unsound:

>  #### Why doesn't middleware use _`process`_?
> …
> In addition, classes that _implement `MiddlewareInterface`_ can be type hinted as _`mixed`_, which results in less strict typing.
> This is generally undesirable, especially when the _`process`_ method uses strict typing.

The first sentence is still valid, whereas the second sentence is clearly unrelated to the first one – same applies to the current version. Or in other words, the current version is just a [fallacious argument](https://en.wikipedia.org/wiki/Formal_fallacy).
