### PR TITLE
Remove statements about how middlewares are dispatched.

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,8 +264,7 @@ additional information._
 ### 5.2 Delegate Design
 
 The `DelegateInterface` defines a single method that accepts a request and
-returns a response. The delegate interface must be implemented by any middleware
-dispatcher that uses middleware implementing `ServerMiddlewareInterface`.
+returns a response.
 
 #### Why isn't the delegate a `callable`?
 
@@ -281,8 +280,6 @@ additional information._
 
 Both the middleware and delegate interface define a `process` method to prevent
 misuse of middleware as delegates.
-
-The implementation of delegate should be defined within middleware dispatching systems.
 
 6. People
 ---------


### PR DESCRIPTION
The statements are out of scope of this PSR, because they describe how middlewares are dispatched and are intended to dictate implementation details of middleware dispatching systems. These are declared non-goals as stated at 3.2:

> ### 3.2 Non-Goals
> * Attempting to define how middleware is dispatched.

Fixes #54