### PR TITLE
Remove misplaced/superfluous compatibility argument.

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,9 +271,6 @@ dispatcher that uses middleware implementing `ServerMiddlewareInterface`.
 
 Using an interface type hint improves runtime safety and IDE support.
 
-In addition, it allows compatibility with existing middleware that already defines
-an `__invoke` method.
-
 _See "discussion of FrameInterface" in [relevant links](#8-relevant-links) for
 additional information._
 


### PR DESCRIPTION
For clarity:
```diff
 ### 5.2 Delegate Design
 …
 #### Why isn't the delegate a `callable`?

 Using an interface type hint improves runtime safety and IDE support.

-In addition, it allows compatibility with existing middleware that already defines
-an `__invoke` method.
```

Obviously, this sentence is off-topic, it is neither about delegates nor `callable`. It may support the _Why doesn't middleware use `__invoke`?_ reasons, but if we rewrite and move it there, it would be superfluous: that section already contains the compatibility argument:

> #### Why doesn't middleware use `__invoke`?
> Doing so would conflict with existing middleware that implements the
> double-pass approach and may want to implement the middleware interface.

Therefore, I suggest to simply remove it.