### PR TITLE
Fix phpdocs

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,11 +225,11 @@ being passed implements a middleware signature, which reduces runtime safety.
 The `ServerMiddlewareInterface` defines a single method that accepts a server
 request and a delegate and must return a response. The middleware may:
 
-- Evolve the request before passing it to the delegate to execute the next
+- Evolve the request before passing it to the delegate to dispatch the next
   available middleware.
 - Evolve the response received from the delegate before returning it.
 - Create and return a response without passing it to the delegate, thereby
-  preventing any further middleware from executing.
+  preventing any further middleware from dispatching.
 
 #### Why doesn't middleware use `__invoke`?
 

--- a/README.md
+++ b/README.md
@@ -225,8 +225,7 @@ being passed implements a middleware signature, which reduces runtime safety.
 The `ServerMiddlewareInterface` defines a single method that accepts a server
 request and a delegate and must return a response. The middleware may:
 
-- Evolve the request before passing it to the delegate to dispatch the next
-  available middleware.
+- Evolve the request before passing it to the delegate to create the response.
 - Evolve the response received from the delegate before returning it.
 - Create and return a response without passing it to the delegate, thereby
   preventing any further middleware from dispatching.

--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ To make it clear that the middleware can only be used in a synchronous, server
 side context.
 
 While not all middleware will need to use the additional methods defined by the
-server request interface, external requests are typically handled asynchronously
+server request interface, external requests are typically processed asynchronously
 and would need to return a [promise][promises] of a response. (This is primarily
 due to the fact that multiple requests can be made in parallel and processed as
 they are returned.) It is outside the scope of this proposal to address the needs

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ significant issues regarding implementation.
 
 The most severe is that passing an empty response has no guarantees that the
 response is in a usable state. This is further exacerbated by the fact that a
-middleware may modify the response before passing it for further dispatching.
+middleware may modify the response before passing it for further processing.
 
 Further compounding the problem is that there is no way to ensure that the
 response body has not been written to, which can lead to incomplete output or

--- a/src/DelegateInterface.php
+++ b/src/DelegateInterface.php
@@ -8,7 +8,7 @@ use Psr\Http\Message\ServerRequestInterface;
 interface DelegateInterface
 {
     /**
-     * Dispatch the next available middleware and return the response.
+     * Process an incoming server request and return the response.
      *
      * @param ServerRequestInterface $request
      *

--- a/src/MiddlewareInterface.php
+++ b/src/MiddlewareInterface.php
@@ -9,7 +9,7 @@ interface MiddlewareInterface
 {
     /**
      * Process an incoming server request and return a response, optionally delegating
-     * to the next middleware component to create the response.
+     * to the next request processor to create the response.
      *
      * @param ServerRequestInterface $request
      * @param DelegateInterface $delegate

--- a/src/MiddlewareInterface.php
+++ b/src/MiddlewareInterface.php
@@ -9,7 +9,7 @@ interface MiddlewareInterface
 {
     /**
      * Process an incoming server request and return a response, optionally delegating
-     * to the next request processor to create the response.
+     * requests to create the response.
      *
      * @param ServerRequestInterface $request
      * @param DelegateInterface $delegate


### PR DESCRIPTION
Because @shadowhand has closed #53, I have to recreate this PR :disappointed: 

@shadowhand I've implemented your suggestions in a way which I believe:
1. solve the issues of #53
2. unifies all the different technical terms

I've only used the already established wording:
1. middlewares are _dispatched_
2. requests and responses are _processed_

@shadowhand I truly believe this PR completely aligns with you intentions, hence please do not close it prematurely – maybe I/we can fix remaining issues.

---

Form the [current `README.md`](https://github.com/http-interop/http-middleware/tree/cff4fb65317875b2bccbb6b7b22eec18b5a96f04)
> ### 3.2 Non-Goals
> * Attempting to define how middleware is dispatched.
> ### 5.2 Delegate Design
>
> The `DelegateInterface` defines a single method that accepts a request and
returns a response. The delegate interface must be implemented by any middleware
dispatcher that uses middleware implementing `ServerMiddlewareInterface`.

Obviously, dispatching a middleware does not necessarily implies the existence of a _next available middleware_ or a _next middleware component_. There are too many real-world use-cases where we want to dispatch only one single middleware; hence, sticking to the current phpdoc wording would make PSR-15 less useful and does not reflect the point of view of the `README.md`.

Moreover PSR-15 should focus on interop of middlewares, the existence of additional middlewares in some frameworks is therefore out of scope. A middleware should only be aware of _sitting_ between a request and a response. Using the [StackPHP](http://stackphp.com) picture:

![stackphp-lambda-middleware](https://cloud.githubusercontent.com/assets/6059032/21763008/f63bf310-d65b-11e6-8a9c-c195b284e24f.png)

### Why _Process_ and not _Dispatch_ at `DelegateInterface`?

This is due to the fact, that we currently have `DelegateInterface::process` and not `DelegateInterface::dispatch`.

### Why request _processor_?

This is also due to the fact, that we currently have `DelegateInterface::process` and not `DelegateInterface::dispatch` or `DelegateInterface::handle` – In my opinion, _request **handler**_ sounds much better and is more common, but there is no reason to introduce another technical term. Furthermore, obviously, a standard should use as few technical terms as possible to not confuse implementers.